### PR TITLE
Remove kvirc. Checksum mismatch. Don't have time to work on the cask.

### DIFF
--- a/modules/people/manifests/charleshbaker.pp
+++ b/modules/people/manifests/charleshbaker.pp
@@ -20,7 +20,6 @@ class people::charleshbaker {
     'gimp',
     'hipchat',
     'iterm2',
-    'kvirc',
     'quicksilver',
     'textwrangler',
     'vagrant',


### PR DESCRIPTION
Remove kvirc. Checksum mismatch. Don't have time to work on the cask.
