### PR TITLE
update for ipython

### DIFF
--- a/modules/people/manifests/charleshbaker.pp
+++ b/modules/people/manifests/charleshbaker.pp
@@ -46,6 +46,6 @@ class people::charleshbaker {
   package { 'ipython':
     provider => pip,
     ensure => installed,
-    require => Package['python']    
+#    require => Package['python']    
   }
 }


### PR DESCRIPTION
removed requirement python installed by default on macosx
